### PR TITLE
Fixes some high priority bugs

### DIFF
--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_tiny.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_tiny.lua
@@ -167,10 +167,14 @@ if IsServer() then
 	
 	function imba_tiny_avalanche:OnProjectileHit_ExtraData(hTarget, vLocation, extradata)
 		local caster = self:GetCaster()
+		local grow_ability = caster:FindAbilityByName("imba_tiny_grow")
 		
 		local duration = self:GetSpecialValueFor("stun_duration")
 		local toss_mult = self:GetSpecialValueFor("toss_damage_multiplier")
-		local radius = self:GetSpecialValueFor("radius") + caster:FindModifierByName("modifier_imba_tiny_rolling_stone"):GetStackCount() * caster:FindAbilityByName("imba_tiny_grow"):GetSpecialValueFor("rolling_stones_aoe")
+		local radius = self:GetSpecialValueFor("radius")
+		if grow_ability then
+			radius = radius + caster:FindModifierByName("modifier_imba_tiny_rolling_stone"):GetStackCount() * caster:FindAbilityByName("imba_tiny_grow"):GetSpecialValueFor("rolling_stones_aoe")
+		end
 		local interval = self:GetSpecialValueFor("tick_interval")
 		local damage = self:GetTalentSpecialValueFor("avalanche_damage") * self:GetSpecialValueFor("tick_interval")		
 		self.repeat_increase = false
@@ -471,9 +475,10 @@ function modifier_tiny_toss_movement:TossLand()
 		self.toss_land_commenced = true
 
 		local caster = self:GetCaster()
+		local rolling_stone_modifier = caster:FindModifierByName("modifier_imba_tiny_rolling_stone")
 		local radius = self:GetAbility():GetSpecialValueFor("radius")
-		if caster:HasModifier("modifier_imba_tiny_rolling_stone") and caster:HasAbility("imba_tiny_grow") then
-		 	radius = radius + caster:FindModifierByName("modifier_imba_tiny_rolling_stone"):GetStackCount() * caster:FindAbilityByName("imba_tiny_grow"):GetSpecialValueFor("rolling_stones_aoe")
+		if rolling_stone_modifier and caster:HasAbility("imba_tiny_grow") then
+		 	radius = radius + rolling_stone_modifier:GetStackCount() * caster:FindAbilityByName("imba_tiny_grow"):GetSpecialValueFor("rolling_stones_aoe")
 		end
 
 		-- Destroy trees at the target point
@@ -483,7 +488,11 @@ function modifier_tiny_toss_movement:TossLand()
 		for _, victim in pairs(victims) do
 			local damage = self.ability:GetSpecialValueFor("toss_damage")
 			if victim == self.parent then
-				damage = damage * (1 + (self.ability:GetSpecialValueFor("bonus_damage_pct") + caster:FindModifierByName("modifier_imba_tiny_rolling_stone"):GetStackCount()) / 100)
+				local damage_multiplier = 1 + self.ability:GetSpecialValueFor("bonus_damage_pct") / 100
+				if rolling_stone_modifier then
+					damage_multiplier = damage_multiplier + rolling_stone_modifier:GetStackCount() / 100
+				end
+				damage = damage * damage_multiplier
 			end
 			if victim:IsBuilding() then
 				damage = damage * self.ability:GetSpecialValueFor("building_dmg") * 0.01

--- a/game/dota_addons/dota_imba/scripts/vscripts/imba.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/imba.lua
@@ -568,7 +568,7 @@ function GameMode:ItemAddedFilter( keys )
 			ParticleManager:ReleaseParticleIndex(item.x_pfx)
 			item.x_pfx = nil
 		end
-		if unit:IsRealHero() then
+		if unit:IsRealHero() or ( unit:GetClassname() == "npc_dota_lone_druid_bear" ) then
 			item:SetPurchaser(nil)
 			item:SetPurchaseTime(0)
 			local rapier_amount = 0

--- a/game/dota_addons/dota_imba/scripts/vscripts/items/item_rapier.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/items/item_rapier.lua
@@ -25,10 +25,11 @@ LinkLuaModifier("modifier_imba_rapier_cursed_curse", "items/item_rapier.lua", LU
 rapier_base_class = class({})
 
 function rapier_base_class:OnOwnerDied(params)
-	local hCaster = self:GetCaster()
-	if not hCaster:IsReincarnating() then
-		self:GetCaster():DropRapier(self, true)
+	local hOwner = self:GetOwner()
+	if hOwner.IsReincarnating and hOwner:IsReincarnating() then
+		return nil
 	end
+	hOwner:DropRapier(self, true)
 end
 
 function rapier_base_class:IsRapier()


### PR DESCRIPTION
* Fixes Avalanche/Toss doing no damage if stolen by Rubick
* Fixes Spirit Bear not dropping rapiers on death
* BEAR NECESSITIES : Spirit Bear can now pick up rapiers normally

`- Chaotic Offering Golem Flaming Fists are proccing on buildings`
Cannot reproduce this. Buildings don't proc Flaming Fists and attacking units near buildings doesn't damage buildings either.
`- Error found hero_slardar.lua line 841, trigger by bashing`
Cannot reproduce this either, bashing doesn't trigger it, nor does bashing a stunned/hexed target does.